### PR TITLE
Update source file: Compile without PIE

### DIFF
--- a/Part 2 - Exploitation/megabeets_0x2.c
+++ b/Part 2 - Exploitation/megabeets_0x2.c
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////
 // Name: megabeets_0x2.c
 // Description: Vulnerable program to teach radare2 framework capabilities.
-// Compilation: $ gcc -m32 -fno-stack-protector megabeets_0x2.c -o megabeets_0x2
+// Compilation: $ gcc -no-pie -m32 -fno-stack-protector megabeets_0x2.c -o megabeets_0x2
 //
 // Author: Itay Cohen (@megabeets_)
 // Website: https://www.megabeets.net


### PR DESCRIPTION
In recent GCC versions compiling with PIE is enabled by default. Correct me if I'm wrong but I think this has to be disabled for the sake of the tutorial: `ir~puts` shows a randomized value for every instance of the application with PIE enabled.

Greetings <3